### PR TITLE
pivotal tracker style git annotations

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,4 +46,12 @@ Basically, that's just creating a YAML configuration file (containing your API k
 
 ## Git Integration
 
-Copy the <tt>post-commit</tt> file into your repo's <tt>.git/hooks</tt> directory, and make sure to execute <tt>chmod +x .git/hooks/post-commit</tt> from the root of your repo. Now, simply mention the ID of an Asana task inside your commit message, and the issue will be closed automatically and a comment with the relevent commit will be posted. For example, if you determine a relevant bug has an ID of 12345 (using the asana command-line client), you could say <tt>git commit -m "this commit fixes issue 12345"</tt>.
+Copy the <tt>post-commit</tt> file into your repo's <tt>.git/hooks</tt> directory, and make sure to execute <tt>chmod +x .git/hooks/post-commit</tt> from the root of your repo.
+
+Now, simply mention the ID of an Asana task inside your commit message, and the issue will be annotated automatically with your commit message and will optionally complete the task. If you're familiar with git annotations with Pivotal Tracker, these will be second nature. Commit message examples:
+
+action | commit
+------- | --------
+annotate a task without finishing it | git commit -m "convert tabs to spaces in sort.c [#1234567890]"
+annotate a task and finish it | git commit -m "fix tricky bug [fixes #1234567890]"
+annotate a task and finish it | git commit -m "finish converting tabs [finishes #1234567890]"

--- a/post-commit
+++ b/post-commit
@@ -4,14 +4,20 @@ require "rubygems"
 require "asana-client"
 
 # get newly committed message
-message = `git log -1 HEAD --pretty=format:%s`.split " "
+message = `git log -1 HEAD --pretty=format:%s`
 commit = `git log -1 HEAD --pretty=format:%H`
 Asana.init
 
-message.each do |word|
-    # check if any word in commit message is an issue id 
-    if word =~ /^\d{10,}$/
-        Asana::Task.finish word
-        Asana::Task.comment word, "closed by commit " + message
-    end
+# finishes a task: [finishes #1234567890] or [fixes #1234567890]
+# comment on a task without finishing: [#1234567890]
+annotations = message.scan /\[(\w+)?\s*#(\d{10,})\]/
+annotations.each do |state, task_id|
+  case state
+  when /^(?:fix|finish)/i
+    # change task state if indicating fix/finish
+    Asana::Task.finish task_id
+  end
+
+  # always comment on the task
+  Asana::Task.comment task_id, "#{commit}\n\n#{message}"
 end


### PR DESCRIPTION
Update post-commit hook to allow task annotations ala git + pivotal tracker integration. Update README in kind.

Annotation format for commit messages:
- [#1234567890]: annotate the task in asana _without_ finishing it
- [fix #1234567890] or [finish #1234567890]: annotate the task in asana _and_ also finish it

In Asana, it posts "#{commit SHA1}\n\n#{commit message}"
