### PR TITLE
Remove "workspace" param from project task list API call

### DIFF
--- a/lib/asana-client.rb
+++ b/lib/asana-client.rb
@@ -207,7 +207,7 @@ module Asana
 
         # get all tasks associated with the current project
         def tasks
-            task_objects = Asana.get "tasks?workspace=#{workspace.id}&project=#{self.id}"
+            task_objects = Asana.get "tasks?project=#{self.id}"
             list = []
 
             task_objects["data"].each do |task|


### PR DESCRIPTION
This param is now rejected by the Asana API with the message
"Must specify exactly one of project, tag, or workspace".

Thanks!
