### PR TITLE
Actual task heading can consist of any kind of character

### DIFF
--- a/lib/asana-client.rb
+++ b/lib/asana-client.rb
@@ -94,7 +94,7 @@ module Asana
         string = args.join " "
 
         # workspace task name: create task in that workspace
-        if string =~ /^(\w+) ([\w ]+)/
+        if string =~ /^(\w+) (.+)/
             # get corresponding workspace 
             workspace = Asana::Workspace.find $1
 
@@ -105,7 +105,7 @@ module Asana
         end
 
         # workspace/project task name: create task in that workspace
-        if string =~ /^(\w+)\/(\w+) ([\w ]+)/
+        if string =~ /^(\w+)\/(\w+) (.+)/
             # get corresponding workspace 
             workspace = Asana::Workspace.find $1
 


### PR DESCRIPTION
Hi! Just found your asana-client gem and I like it! There was only one problem: tasks with other characters than words would not get added to Asana, so I've fixed that in this pull request. Hopefully you can merge it and publish the gem, so me and my team mates can keep using it.
