### PR TITLE
Add -m and -c flags to get assigned, and all (as opposed to only incomplete) respectively.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,9 +19,13 @@ Basically, that's just creating a YAML configuration file (containing your API k
 
     $ asana workspace
 
+To also list completed tasks, add the `-c` flag.
+
 ### View all of the tasks in a project
 
     $ asana workspace/project
+
+As for workspaces, add the `-c` flag to also list completed tasks.
 
 ### Create a new task in a workspace
 

--- a/README.markdown
+++ b/README.markdown
@@ -26,6 +26,7 @@ To also list completed tasks, add the `-c` flag.
     $ asana workspace/project
 
 As for workspaces, add the `-c` flag to also list completed tasks.
+The `-m` flag can be given to only list tasks assigned to you.
 
 ### Create a new task in a workspace
 

--- a/lib/asana-client.rb
+++ b/lib/asana-client.rb
@@ -15,6 +15,7 @@ require "chronic"
 module Asana
 
     API_URL = "https://app.asana.com/api/1.0/"
+    @show_completed = false
 
     # initialize config values
     def Asana.init
@@ -30,6 +31,11 @@ module Asana
         # no arguments given
         if args.empty?
             abort "Nothing to do here."
+        end
+
+        if args.include? "-c"
+            @show_completed = true
+            args = args - ["-c"]
         end
 
         # concatenate array into a string
@@ -49,7 +55,8 @@ module Asana
             abort "Workspace not found!" unless workspace
 
             # display all tasks in workspace
-            puts workspace.tasks unless workspace.tasks.empty?
+            tasks = workspace.tasks @show_completed
+            puts tasks unless tasks.empty?
             exit
         end
 
@@ -64,7 +71,8 @@ module Asana
             abort "Project not found!" unless project
 
             # display all tasks in project
-            puts project.tasks unless project.tasks.empty?
+            tasks = project.tasks @show_completed
+            puts tasks unless tasks.empty?
             exit
         end
 
@@ -206,8 +214,12 @@ module Asana
         end
 
         # get all tasks associated with the current project
-        def tasks
-            task_objects = Asana.get "tasks?project=#{self.id}"
+        def tasks(completed)
+            lookup = "tasks?project=#{self.id}"
+            if not completed
+                lookup += "&completed_since=now"
+            end
+            task_objects = Asana.get lookup
             list = []
 
             task_objects["data"].each do |task|
@@ -347,9 +359,13 @@ module Asana
             list
         end
 
-        # get tasks assigned to me within this workspace
-        def tasks
-            task_objects = Asana.get "tasks?workspace=#{self.id}&assignee=me"
+        # get tasks within this workspace
+        def tasks(completed)
+            lookup = "tasks?workspace=#{self.id}&assignee=me"
+            if not completed
+                lookup += "&completed_since=now"
+            end
+            task_objects = Asana.get lookup
             list = []
 
             task_objects["data"].each do |task|


### PR DESCRIPTION
`-m` when looking up a project will list only tasks assigned to me. No change to default behaviour.

`-c` when looking up tasks for either a project or a workspace will list all tasks (the current default). When `-c` is not given, only incomplete tasks are listed.
